### PR TITLE
Feature/handle empty irma attrs

### DIFF
--- a/client/src/components/Demo2/Demo2.tsx
+++ b/client/src/components/Demo2/Demo2.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useEffect, useReducer } from 'react';
 import createIrmaSession from '@services/createIrmaSession';
 import getGGW from '@services/getGGW';
-import content, { insertInPlaceholders } from '@services/content';
+import content, { insertInPlaceholders, reduceAndTranslateEmptyVars } from '@services/content';
 import ReactMarkDown from 'react-markdown';
 import * as AscLocal from '@components/LocalAsc/LocalAsc';
 import { Link, Accordion } from '@amsterdam/asc-ui';
@@ -19,7 +19,6 @@ import ContentBlock from '@components/ContentBlock/ContentBlock';
 import WhyIRMA from '@components/WhyIRMA/WhyIRMA';
 import preloadDemoImages from '@services/preloadImages';
 import { startSurvey as startUsabillaSurvey } from '@services/usabilla';
-import { reduceAndTranslateEmptyVars } from '@components/Demo4/Demo4';
 
 export interface IProps {}
 
@@ -71,8 +70,7 @@ const Demo2: React.FC<IProps> = () => {
                 response['over18'] === 'ja';
 
             if (!response['zipcode']) {
-                newState.hasEmptyVars = true;
-                newState.emptyVars = [...state.emptyVars, 'zipcode'];
+                newState.emptyVars.push('zipcode');
             } else {
                 const postcode = response['zipcode'].replace(/ /, '');
 
@@ -94,7 +92,7 @@ const Demo2: React.FC<IProps> = () => {
         return response;
     };
 
-    const { hasResult, hasError, hasEmptyVars, emptyVars, isOver18, wijk, ggw, code } = state;
+    const { hasResult, hasError, emptyVars, isOver18, wijk, ggw, code } = state;
 
     // Preload demo images
     useEffect(() => {
@@ -145,7 +143,7 @@ const Demo2: React.FC<IProps> = () => {
                     dataTestId="hasErrorAlert"
                 />
             );
-        } else if (hasEmptyVars) {
+        } else if (emptyVars.length > 0) {
             return (
                 <AscLocal.Alert
                     color={AscLocal.AlertColor.ERROR}

--- a/client/src/components/Demo2/Demo2.tsx
+++ b/client/src/components/Demo2/Demo2.tsx
@@ -19,22 +19,27 @@ import ContentBlock from '@components/ContentBlock/ContentBlock';
 import WhyIRMA from '@components/WhyIRMA/WhyIRMA';
 import preloadDemoImages from '@services/preloadImages';
 import { startSurvey as startUsabillaSurvey } from '@services/usabilla';
+import { reduceAndTranslateEmptyVars } from '@components/Demo4/Demo4';
 
 export interface IProps {}
 
 interface IState {
-    hasResult?: boolean;
-    hasError?: boolean;
-    isOver18?: null | boolean;
-    wijk?: string;
-    ggw?: string;
-    code?: string;
+    hasResult: boolean;
+    hasError: boolean;
+    hasEmptyVars: boolean;
+    emptyVars: string[];
+    isOver18: null | boolean;
+    wijk: string;
+    ggw: string;
+    code: string;
 }
 
 const initialState: IState = {
     hasResult: false,
     hasError: false,
     isOver18: null,
+    hasEmptyVars: false,
+    emptyVars: [],
     wijk: '',
     ggw: '',
     code: ''
@@ -56,11 +61,8 @@ const Demo2: React.FC<IProps> = () => {
         );
         const newState: IState = { ...initialState };
         if (response) {
-            const postcode = response['zipcode'].replace(/ /, '');
             newState.hasResult = true;
             newState.hasError = false;
-
-            const ggwResponse = await getGGW(postcode);
 
             newState.isOver18 =
                 response['over18'] === 'Yes' ||
@@ -68,10 +70,19 @@ const Demo2: React.FC<IProps> = () => {
                 response['over18'] === 'Ja' ||
                 response['over18'] === 'ja';
 
-            if (ggwResponse) {
-                newState.wijk = ggwResponse.buurtcombinatieNamen;
-                newState.code = ggwResponse.ggwCode;
-                newState.ggw = ggwResponse.ggwNaam;
+            if (!response['zipcode']) {
+                newState.hasEmptyVars = true;
+                newState.emptyVars = [...state.emptyVars, 'zipcode'];
+            } else {
+                const postcode = response['zipcode'].replace(/ /, '');
+
+                const ggwResponse = await getGGW(postcode);
+
+                if (ggwResponse) {
+                    newState.wijk = ggwResponse.buurtcombinatieNamen;
+                    newState.code = ggwResponse.ggwCode;
+                    newState.ggw = ggwResponse.ggwNaam;
+                }
             }
         } else {
             newState.hasError = true;
@@ -83,7 +94,7 @@ const Demo2: React.FC<IProps> = () => {
         return response;
     };
 
-    const { hasResult, hasError, isOver18, wijk, ggw, code } = state;
+    const { hasResult, hasError, hasEmptyVars, emptyVars, isOver18, wijk, ggw, code } = state;
 
     // Preload demo images
     useEffect(() => {
@@ -131,6 +142,18 @@ const Demo2: React.FC<IProps> = () => {
                     iconSize={22}
                     heading={content.demoErrorAlert.heading}
                     content={content.demoErrorAlert.content}
+                    dataTestId="hasErrorAlert"
+                />
+            );
+        } else if (hasEmptyVars) {
+            return (
+                <AscLocal.Alert
+                    color={AscLocal.AlertColor.ERROR}
+                    icon={<AlertIcon />}
+                    iconSize={22}
+                    heading={content.demoEmptyVarsAlert.heading}
+                    content={content.demoEmptyVarsAlert.content}
+                    contentExtended={`${reduceAndTranslateEmptyVars(state.emptyVars)}.`}
                     dataTestId="hasErrorAlert"
                 />
             );

--- a/client/src/components/Demo2/Demo2.tsx
+++ b/client/src/components/Demo2/Demo2.tsx
@@ -25,7 +25,6 @@ export interface IProps {}
 interface IState {
     hasResult: boolean;
     hasError: boolean;
-    hasEmptyVars: boolean;
     emptyVars: string[];
     isOver18: null | boolean;
     wijk: string;
@@ -37,7 +36,6 @@ const initialState: IState = {
     hasResult: false,
     hasError: false,
     isOver18: null,
-    hasEmptyVars: false,
     emptyVars: [],
     wijk: '',
     ggw: '',

--- a/client/src/components/Demo4/Demo4.tsx
+++ b/client/src/components/Demo4/Demo4.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useReducer } from 'react';
 import createIrmaSession from '@services/createIrmaSession';
-import content from '@services/content';
+import content, { reduceAndTranslateEmptyVars } from '@services/content';
 import ReactMarkDown from 'react-markdown';
 import defList from '@services/deflist';
 import * as AscLocal from '@components/LocalAsc/LocalAsc';
@@ -25,15 +25,6 @@ export interface IProps {}
 
 const OPTIONAL_IRMA_ATTRIBUTES = ['houseNumber'];
 
-export function reduceAndTranslateEmptyVars(emptyVars) {
-    return emptyVars
-        .reduce(
-            (acc, varToTranslate) => acc + `${content.translatedIrmaAttributes[varToTranslate]}, `,
-            'De volgende gegevens ontbreken: '
-        )
-        .slice(0, -2);
-}
-
 const Demo4: React.FC<IProps> = () => {
     const formEl = useRef(null);
 
@@ -46,8 +37,6 @@ const Demo4: React.FC<IProps> = () => {
         }
         return '';
     }
-
-    console.log({ state });
 
     const validateForm = () => {
         const el = formEl.current.querySelector('input[name=geveltuin]:checked');
@@ -106,7 +95,7 @@ const Demo4: React.FC<IProps> = () => {
         alt: content.responsiveImages.demo4.header.alt
     });
 
-    const { hasResult, hasError, hasEmptyVars, formValid } = state;
+    const { hasResult, hasError, emptyVars, formValid } = state;
 
     // Update header image
     useEffect(() => {
@@ -168,7 +157,7 @@ const Demo4: React.FC<IProps> = () => {
                     />
                 )}
 
-                {hasEmptyVars && !hasError && (
+                {emptyVars.length > 0 && !hasError && (
                     <AscLocal.Alert
                         color={AscLocal.AlertColor.ERROR}
                         icon={<Alert />}
@@ -180,7 +169,7 @@ const Demo4: React.FC<IProps> = () => {
                     />
                 )}
 
-                {hasResult && !hasError && !hasEmptyVars && (
+                {hasResult && !hasError && emptyVars.length === 0 && (
                     <AscLocal.Alert
                         color={AscLocal.AlertColor.SUCCESS}
                         icon={<Checkmark />}

--- a/client/src/components/Demo4/Demo4.tsx
+++ b/client/src/components/Demo4/Demo4.tsx
@@ -65,7 +65,6 @@ const Demo4: React.FC<IProps> = () => {
                 credentialSource === CredentialSource.DEMO && { demo: true }
             );
             if (response) {
-                const { fullname } = response;
                 dispatch({
                     type: 'setProperties',
                     payload: {

--- a/client/src/components/Demo4/Demo4.tsx
+++ b/client/src/components/Demo4/Demo4.tsx
@@ -81,14 +81,10 @@ const Demo4: React.FC<IProps> = () => {
                     type: 'setProperties',
                     payload: {
                         name: response['fullname'],
-                        street:
-                            response['street'] && response['houseNumber']
-                                ? `${response['street']} ${response['houseNumber']}`
-                                : response['street'],
-                        city:
-                            response['zipcode'] && response['city']
-                                ? `${response['zipcode']}, ${response['city']}`
-                                : response['city'],
+                        street: response['street'],
+                        houseNumber: response['houseNumber'],
+                        zipcode: response['zipcode'],
+                        city: response['city'],
                         telephone: response['mobilenumber'],
                         email: response['email']
                     }

--- a/client/src/components/Demo4/reducer.ts
+++ b/client/src/components/Demo4/reducer.ts
@@ -1,7 +1,6 @@
 interface IState {
     hasResult: boolean;
     hasError: boolean;
-    hasEmptyVars: boolean;
     emptyVars: string[];
     formValid: boolean;
     irmaAttributes: {
@@ -34,7 +33,6 @@ interface IAction {
 export const initialState: IState = {
     hasResult: false,
     hasError: false,
-    hasEmptyVars: false,
     emptyVars: [],
     formValid: true,
     irmaAttributes: {
@@ -93,7 +91,6 @@ export const reducer = (state: IState, action: IAction): IState => {
         case 'setEmptyVars':
             return {
                 ...state,
-                hasEmptyVars: true,
                 emptyVars: [
                     ...state.emptyVars,
                     action.payload['emptyVar']

--- a/client/src/components/Demo4/reducer.ts
+++ b/client/src/components/Demo4/reducer.ts
@@ -1,13 +1,17 @@
 interface IState {
-    hasResult?: boolean;
-    hasError?: boolean;
-    formValid?: boolean;
-    owner?: string;
-    name?: string;
-    street?: string;
-    city?: string;
-    telephone?: string;
-    email?: string;
+    hasResult: boolean;
+    hasError: boolean;
+    hasEmptyVars: boolean;
+    emptyVars: string[];
+    formValid: boolean;
+    irmaAttributes: {
+        owner: string;
+        name: string;
+        street: string;
+        city: string;
+        telephone: string;
+        email: string;
+    }
 }
 
 interface IAction {
@@ -19,19 +23,24 @@ interface IAction {
         city?: string;
         telephone?: string;
         email?: string;
+        emptyVar?: string;
     };
 }
 
 export const initialState: IState = {
     hasResult: false,
     hasError: false,
+    hasEmptyVars: false,
+    emptyVars: [];
     formValid: true,
-    owner: '',
-    name: '',
-    street: '',
-    city: '',
-    telephone: '',
-    email: ''
+    irmaAttributes: {
+        owner: '',
+        name: '',
+        street: '',
+        city: '',
+        telephone: '',
+        email: ''
+    }
 };
 
 export const reducer = (state: IState, action: IAction): IState => {
@@ -40,7 +49,10 @@ export const reducer = (state: IState, action: IAction): IState => {
             return {
                 ...state,
                 formValid: true,
-                owner: action.payload.owner
+                irmaAttributes: {
+                    ...state.irmaAttributes,
+                    owner: action.payload.owner
+                }
             };
 
         case 'invalidateForm':
@@ -54,11 +66,14 @@ export const reducer = (state: IState, action: IAction): IState => {
                 ...state,
                 hasResult: true,
                 hasError: false,
-                name: action.payload.name,
-                street: action.payload.street,
-                city: action.payload.city,
-                telephone: action.payload.telephone,
-                email: action.payload.email
+                irmaAttributes: {
+                    ...state.irmaAttributes,
+                    name: action.payload['name'],
+                    street: action.payload['street'],
+                    city: action.payload['city'],
+                    telephone: action.payload['telephone'],
+                    email: action.payload['email']
+                }
             };
 
         case 'setError':
@@ -66,6 +81,16 @@ export const reducer = (state: IState, action: IAction): IState => {
                 ...state,
                 hasError: true
             };
+
+        case 'setEmptyVars':
+            return {
+                ...state,
+                hasEmptyVars: true;
+                emptyVars: [
+                    ...state.emptyVars,
+                    action.payload['emptyVar']
+                ]
+            }
 
         default:
             return state;

--- a/client/src/components/Demo4/reducer.ts
+++ b/client/src/components/Demo4/reducer.ts
@@ -8,6 +8,8 @@ interface IState {
         owner: string;
         name: string;
         street: string;
+        houseNumber: string;
+        zipcode: string;
         city: string;
         telephone: string;
         email: string;
@@ -20,7 +22,9 @@ interface IAction {
         owner?: string;
         name?: string;
         street?: string;
+        houseNumber?: string;
         city?: string;
+        zipcode?: string;
         telephone?: string;
         email?: string;
         emptyVar?: string;
@@ -37,6 +41,8 @@ export const initialState: IState = {
         owner: '',
         name: '',
         street: '',
+        houseNumber: '',
+        zipcode: '',
         city: '',
         telephone: '',
         email: ''
@@ -70,6 +76,8 @@ export const reducer = (state: IState, action: IAction): IState => {
                     ...state.irmaAttributes,
                     name: action.payload['name'],
                     street: action.payload['street'],
+                    houseNumber: action.payload['houseNumber'],
+                    zipcode: action.payload['zipcode'],
                     city: action.payload['city'],
                     telephone: action.payload['telephone'],
                     email: action.payload['email']

--- a/client/src/components/Demo4/reducer.ts
+++ b/client/src/components/Demo4/reducer.ts
@@ -31,7 +31,7 @@ export const initialState: IState = {
     hasResult: false,
     hasError: false,
     hasEmptyVars: false,
-    emptyVars: [];
+    emptyVars: [],
     formValid: true,
     irmaAttributes: {
         owner: '',

--- a/client/src/components/Demo4/reducer.ts
+++ b/client/src/components/Demo4/reducer.ts
@@ -85,7 +85,7 @@ export const reducer = (state: IState, action: IAction): IState => {
         case 'setEmptyVars':
             return {
                 ...state,
-                hasEmptyVars: true;
+                hasEmptyVars: true,
                 emptyVars: [
                     ...state.emptyVars,
                     action.payload['emptyVar']

--- a/client/src/components/LocalAsc/LocalAsc.tsx
+++ b/client/src/components/LocalAsc/LocalAsc.tsx
@@ -201,7 +201,7 @@ export const Alert = styled(
                             <>
                                 {heading && <Heading forwardedAs="h3">{heading}</Heading>}
                                 <Paragraph>{content}</Paragraph>
-                                <Paragraph>{contentExtended}</Paragraph>
+                                {contentExtended && <Paragraph>{contentExtended}</Paragraph>}
                             </>
                         ) : (
                             children

--- a/client/src/components/LocalAsc/LocalAsc.tsx
+++ b/client/src/components/LocalAsc/LocalAsc.tsx
@@ -160,6 +160,7 @@ interface IAlertProps {
     iconSize?: number;
     heading?: string;
     content?: string;
+    contentExtended?: string;
     dataTestId?: string;
 }
 
@@ -170,7 +171,18 @@ export enum AlertColor {
 }
 
 export const Alert = styled(
-    ({ children, icon, iconUrl, iconSize, className, heading, content, color, dataTestId }: IAlertProps) => {
+    ({
+        children,
+        icon,
+        iconUrl,
+        iconSize,
+        className,
+        heading,
+        content,
+        contentExtended,
+        color,
+        dataTestId
+    }: IAlertProps) => {
         const themeContext = { theme: useContext(ThemeContext) as Theme.ThemeInterface };
         const iconColor =
             color === AlertColor.PRIMARY || color === AlertColor.SUCCESS
@@ -189,6 +201,7 @@ export const Alert = styled(
                             <>
                                 {heading && <Heading forwardedAs="h3">{heading}</Heading>}
                                 <Paragraph>{content}</Paragraph>
+                                <Paragraph>{contentExtended}</Paragraph>
                             </>
                         ) : (
                             children

--- a/client/src/services/content.ts
+++ b/client/src/services/content.ts
@@ -76,6 +76,10 @@ Ga naar de [website van IRMA](https://irma.app/?lang=nl)`
         heading: `Niets doorgegeven`,
         content: `U heeft uw gegevens niet doorgegeven aan de demosite van de gemeente Amsterdam.`
     },
+    demoEmptyVarsAlert: {
+        heading: `Ontbrekende gegevens`,
+        content: `U heeft niet alle gegevens doorgegeven die nodig zijn.`
+    },
     demo1: {
         breadcrumbs: `- [Home](/)
 - [Demo 1: Leeftijd aantonen](/leeftijd-aantonen)`,
@@ -273,7 +277,7 @@ Bent u de eigenaar van de woning waar de geveltuin komt?  \n
 Naam  \n
 :   [name]  \n
 Straat en huisnummer  \n
-:   [street]  \n
+:   [street] [houseNumber]\n
 Postcode en plaats  \n
 :   [city]\n
 Telefoonnummer  \n
@@ -497,5 +501,14 @@ Informatie over toerisme, cultuur, uitgaan, evenementen en meer vindt u op [I am
 1. Scan de QR-code hieronder met uw IRMA-app.  \n
 2. Kies in uw IRMA-app of u de gevraagde gegevens wilt doorgeven om in te loggen op Mijn Amsterdam.`,
         knop: 'Inloggen met IRMA'
+    },
+    translatedIrmaAttributes: {
+        fullname: 'volledige naam',
+        street: 'straat',
+        housenumber: 'huisnummer',
+        city: 'stad',
+        zipcode: 'postcode',
+        email: 'email',
+        mobilenumber: 'telefoonnummer mobiel'
     }
 };

--- a/client/src/services/content.ts
+++ b/client/src/services/content.ts
@@ -279,7 +279,7 @@ Naam  \n
 Straat en huisnummer  \n
 :   [street] [houseNumber]\n
 Postcode en plaats  \n
-:   [city]\n
+:   [zipcode], [city]\n
 Telefoonnummer  \n
 :   [telephone]  \n
 E-mail  \n

--- a/client/src/services/content.ts
+++ b/client/src/services/content.ts
@@ -12,7 +12,17 @@ export const insertInPlaceholders = (sentence: string, values: string | string[]
     }
 };
 
-export default {
+export const reduceAndTranslateEmptyVars = (emptyVars) => {
+    return emptyVars
+        .reduce(
+            (acc, varToTranslate) => acc + `${content.translatedIrmaAttributes[varToTranslate]}, `,
+            content.demoEmptyVarsAlert.contentExtended
+        )
+        .slice(0, -2);
+}
+
+
+const content = {
     home: {
         breadcrumbs: `- [Home](/)`,
         title: `# Probeer IRMA uit`,
@@ -78,7 +88,8 @@ Ga naar de [website van IRMA](https://irma.app/?lang=nl)`
     },
     demoEmptyVarsAlert: {
         heading: `Ontbrekende gegevens`,
-        content: `U heeft niet alle gegevens doorgegeven die nodig zijn.`
+        content: `U heeft niet alle gegevens doorgegeven die nodig zijn.`,
+        contentExtended: `De volgende gegevens ontbreken: `
     },
     demo1: {
         breadcrumbs: `- [Home](/)
@@ -512,3 +523,6 @@ Informatie over toerisme, cultuur, uitgaan, evenementen en meer vindt u op [I am
         mobilenumber: 'telefoonnummer mobiel'
     }
 };
+
+export default content;
+


### PR DESCRIPTION
I have updated demo2 and demo4 to handle the return of empty but required irma-attributes from an irma-session.

When they occur, it should be shown as in the design below. Before, the app crashed because they were written as ' ' and the ReactMarkDown couldn't handle that.

Design: https://projects.invisionapp.com/d/main?origin=v7#/console/20105128/441865897/inspect?scrollOffset=6680