### PR TITLE
Fix: change favicon color for Safari

### DIFF
--- a/client/src/index.ejs
+++ b/client/src/index.ejs
@@ -12,7 +12,7 @@
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
         <link rel="manifest" href="/site.webmanifest" />
-        <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
+        <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#ec0000" />
         <meta name="msapplication-TileColor" content="#da532c" />
         <meta name="theme-color" content="#ffffff" />
         <title>Digitale Identiteit - IRMA demo's</title>


### PR DESCRIPTION
Changed the color of the pinned-tab icon a.k.a. favicon for Safari browser to be in line with all the other browsers.